### PR TITLE
Add redirects for maas 2.1 installconfig pages

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -16,8 +16,8 @@ maas(/|/en/?|/2.1/?)?: /maas/2.1/en/
 # On 12/01/2017
 core/en/guides/build-device/assertions: /core/en/reference/assertions
 
-maas/2.1/en/installconfig-deploy-nodes: maas/2.1/en/installconfig-nodes-deploy
-maas/2.1/en/installconfig-gui: maas/2.1/en/installconfig-webui
-maas/2.1/en/installconfig-hwe-kernels: maas/2.1/en/installconfig-nodes-ubuntu-kernels
-maas/2.1/en/installconfig-kernel: maas/2.1/en/installconfig-nodes-kernel-boot-options
-maas/2.1/en/installconfig-server-iso: maas/2.1/en/installconfig-iso-install
+maas/2.1/en/installconfig-deploy-nodes: /maas/2.1/en/installconfig-nodes-deploy
+maas/2.1/en/installconfig-gui: /maas/2.1/en/installconfig-webui
+maas/2.1/en/installconfig-hwe-kernels: /maas/2.1/en/installconfig-nodes-ubuntu-kernels
+maas/2.1/en/installconfig-kernel: /maas/2.1/en/installconfig-nodes-kernel-boot-options
+maas/2.1/en/installconfig-server-iso: /maas/2.1/en/installconfig-iso-install

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -15,3 +15,9 @@ maas(/|/en/?|/2.1/?)?: /maas/2.1/en/
 # Pages redirects:
 # On 12/01/2017
 core/en/guides/build-device/assertions: /core/en/reference/assertions
+
+maas/2.1/en/installconfig-deploy-nodes: maas/2.1/en/installconfig-nodes-deploy
+maas/2.1/en/installconfig-gui: maas/2.1/en/installconfig-webui
+maas/2.1/en/installconfig-hwe-kernels: maas/2.1/en/installconfig-nodes-ubuntu-kernels
+maas/2.1/en/installconfig-kernel: maas/2.1/en/installconfig-nodes-kernel-boot-options
+maas/2.1/en/installconfig-server-iso: maas/2.1/en/installconfig-iso-install


### PR DESCRIPTION
Add redirects per #49 

# QA
Run server and check the links redirect to the correct location.
This can be done with curl, ie:
```
curl --silent -I http://127.0.0.1:8007/maas/2.1/en/installconfig-deploy-nodes | grep Location
```