### PR TITLE
Add docs for documentation-builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ node_modules/
 yarn.lock
 phone-docs
 templates/phone
+templates/documentation-builder/
+documentation-builder/

--- a/rebuild-docs
+++ b/rebuild-docs
@@ -4,9 +4,11 @@ set -euo pipefail
 
 maas_dir=maas-docs
 core_dir=ubuntu-core-docs
+builder=documentation-builder
 
 rm -rf ${maas_dir} && git clone https://github.com/canonicalltd/maas-docs.git ${maas_dir} || true
 rm -rf ${core_dir} && git clone https://github.com/canonicalltd/ubuntu-core-docs.git ${core_dir} || true
+rm -rf ${builder} && git clone https://github.com/canonicalltd/documentation-builder.git ${builder} || true
 
 # Extra build steps for Ubuntu Core docs
 (
@@ -37,6 +39,18 @@ documentation-builder --base-directory ${core_dir}  \
                       --search-domain 'docs.ubuntu.com/core'  \
                       --media-url '/static/media/core'  \
                       --tag-manager-code 'GTM-K92JCQ'  \
+                      --no-link-extensions \
+                      --force
+
+documentation-builder --base-directory ${builder}  \
+                      --source-folder docs  \
+                      --site-root '/documentation-builder/'  \
+                      --output-path templates/documentation-builder  \
+                      --output-media-path static/media/documentation-builder  \
+                      --search-url '/search'  \
+                      --search-placeholder 'Search Builder docs'  \
+                      --search-domain 'docs.ubuntu.com/documentation-builder'  \
+                      --media-url '/static/media/documentation-builder'  \
                       --no-link-extensions \
                       --force
 

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1,16 +1,15 @@
 # Redirect project section roots to English language
-core/?: /core/en/
-phone/?: /phone/en/
+(?P<project>[^/]+)/?: /{project}/en/
 maas(/|/en/?|/2.1/?)?: /maas/2.1/en/
 
 # Add slash to language and version folders, and remove "index"
-(?P<project>maas|core|phone)/(?P<language>[a-zA-Z]{2})(/index)?: /{project}/{language}/
-(?P<project>maas|core|phone)/(?P<version>[0-9-._]+|devel)/: /{project}/{version}/en/
-(?P<project>maas|core|phone)/(?P<version>[a-zA-Z0-9-._]+)(/index)?: /{project}/{version}/en/
-(?P<project>maas|core|phone)/(?P<version>[a-zA-Z0-9-._]+)/(?P<language>[a-zA-Z]{2})(/index)?: /{project}/{version}/{language}/
+(?P<project>[^/]+)/(?P<language>[a-zA-Z]{2})(/index)?: /{project}/{language}/
+(?P<project>[^/]+)/(?P<version>[0-9-._]+|devel)/: /{project}/{version}/en/
+(?P<project>[^/]+)/(?P<version>[a-zA-Z0-9-._]+)(/index)?: /{project}/{version}/en/
+(?P<project>[^/]+)/(?P<version>[a-zA-Z0-9-._]+)/(?P<language>[a-zA-Z]{2})(/index)?: /{project}/{version}/{language}/
 
 # Remove trailing slash or .html from document URLs
-(?P<project>maas|core|phone)/(?P<version>[a-zA-Z0-9-._]+/)?(?P<language>[a-zA-Z]{2})/(?P<document>.*)(/|.html): /{project}/{version}{language}/{document}
+(?P<project>[^/]+)/(?P<version>[a-zA-Z0-9-._]+/)?(?P<language>[a-zA-Z]{2})/(?P<document>.*)(/|.html): /{project}/{version}{language}/{document}
 
 # Pages redirects:
 # On 12/01/2017

--- a/templates/index.html
+++ b/templates/index.html
@@ -22,7 +22,7 @@
           </thead>
           <tbody>
               <tr>
-                  <td><a href="http://maas.io" class="p-link--external">MAAS</a></td>
+                  <td><a href="https://maas.io" class="p-link--external">MAAS</a></td>
                   <td>
                       <p>Documentation for MAAS (Metal as a Service).</p>
                       <p><a href="/maas/2.1/en/">Read the MAAS documentation&nbsp;&rsaquo;</a></p>
@@ -36,10 +36,17 @@
                   </td>
               </tr>
               <tr>
-                  <td><a href="http://snapcraft.io" class="p-link--external">Snapcraft</a></td>
+                  <td><a href="https://snapcraft.io" class="p-link--external">Snapcraft</a></td>
                   <td>
                       <p>Developer documentation to learn how to snap your apps for easy cross platform distribution and updates that just work.</p>
-                      <p><a href="http://snapcraft.io/docs" class="p-link--external">Read the Snapcraft documentation</a></p>
+                      <p><a href="https://snapcraft.io/docs" class="p-link--external">Read the Snapcraft documentation</a></p>
+                  </td>
+              </tr>
+              <tr>
+                  <td><a href="https://github.com/canonicalltd/documentation-builder" class="p-link--external">documentation-builder</a></td>
+                  <td>
+                      <p>A tool for generating documentation HTML from Markdown in the standard Canonical format.</p>
+                      <p><a href="/documentation-builder">Read the documentation-builder documentation</a></p>
                   </td>
               </tr>
           </tbody>


### PR DESCRIPTION
Fixes #47

QA
--

``` bash
./run
```

Go to <http://127.0.0.1:8007/>, click "Read the documentation-builder documentation". Check it works and looks okay.

If you have issues with the Builder documentation itself, please file them as [issues against documentation-builder](https://github.com/canonicalltd/documentation-builder/issues/new).