### PR TITLE
Add Conjure-up docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ phone-docs
 templates/phone
 templates/documentation-builder/
 documentation-builder/
+conjure-up-docs/
+templates/conjure-up/

--- a/rebuild-docs
+++ b/rebuild-docs
@@ -4,10 +4,12 @@ set -euo pipefail
 
 maas_dir=maas-docs
 core_dir=ubuntu-core-docs
+conjureup_dir=conjure-up-docs
 builder=documentation-builder
 
 rm -rf ${maas_dir} && git clone https://github.com/canonicalltd/maas-docs.git ${maas_dir} || true
 rm -rf ${core_dir} && git clone https://github.com/canonicalltd/ubuntu-core-docs.git ${core_dir} || true
+rm -rf ${conjureup_dir} && git clone https://github.com/canonicalltd/docs-conjure-up.git ${conjureup_dir} || true
 rm -rf ${builder} && git clone https://github.com/canonicalltd/documentation-builder.git ${builder} || true
 
 # Extra build steps for Ubuntu Core docs
@@ -42,6 +44,18 @@ documentation-builder --base-directory ${core_dir}  \
                       --no-link-extensions \
                       --force
 
+documentation-builder --base-directory ${conjureup_dir}  \
+                      --site-root '/conjure-up/'  \
+                      --output-path templates/conjure-up  \
+                      --output-media-path static/media/conjure-up  \
+                      --search-url '/search'  \
+                      --search-placeholder 'Search Conjure-up docs'  \
+                      --search-domain 'docs.ubuntu.com/conjure-up'  \
+                      --media-url '/static/media/conjure-up'  \
+                      --tag-manager-code 'GTM-K92JCQ'  \
+                      --no-link-extensions \
+                      --force
+
 documentation-builder --base-directory ${builder}  \
                       --source-folder docs  \
                       --site-root '/documentation-builder/'  \
@@ -53,4 +67,3 @@ documentation-builder --base-directory ${builder}  \
                       --media-url '/static/media/documentation-builder'  \
                       --no-link-extensions \
                       --force
-

--- a/templates/index.html
+++ b/templates/index.html
@@ -46,7 +46,7 @@
                   <td><a href="https://conjure-up.io" class="p-link--external">Conjure-up</a></td>
                   <td>
                       <p>Documentation for Conjure-up.</p>
-                      <p><a href="/conjure-up/en" class="p-link--external">Read the Conjure-up documentation</a></p>
+                      <p><a href="/conjure-up/en">Read the Conjure-up documentation</a></p>
                   </td>
               </tr>
               <tr>

--- a/templates/index.html
+++ b/templates/index.html
@@ -43,6 +43,13 @@
                   </td>
               </tr>
               <tr>
+                  <td><a href="https://conjure-up.io" class="p-link--external">Conjure-up</a></td>
+                  <td>
+                      <p>Documentation for Conjure-up.</p>
+                      <p><a href="/conjure-up/en" class="p-link--external">Read the Conjure-up documentation</a></p>
+                  </td>
+              </tr>
+              <tr>
                   <td><a href="https://github.com/canonicalltd/documentation-builder" class="p-link--external">documentation-builder</a></td>
                   <td>
                       <p>A tool for generating documentation HTML from Markdown in the standard Canonical format.</p>


### PR DESCRIPTION
Add Conjure-up docs from https://github.com/CanonicalLtd/docs-conjure-up/

## QA
 - ./rebuild-docs
 - ./run
 - Go to http://localhost:8007/ and check the Conjure-up section and click through
 - You should end up at http://localhost:8007/conjure-up/en
 - Click around a bit, make sure things look pretty