### PR TITLE
Don't 301 /search

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1,5 +1,5 @@
 # Redirect project section roots to English language
-(?P<project>[^/]+)/?: /{project}/en/
+(?P<project>((?!search)[^/])+)/?: /{project}/en/
 maas(/|/en/?|/2.1/?)?: /maas/2.1/en/
 
 # Add slash to language and version folders, and remove "index"


### PR DESCRIPTION
search is currently broken, 'cos it redirects: https://docs.ubuntu.com/search

This should fix it.

QA
--

**Connect to Canonical VPN**

``` bash
./rebuild-docs
./run
```

Go to <http://127.0.0.1:8007/maas>, use the search box, top left, check it works