### PR TITLE
No longer need special redirect for landscape

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -14,9 +14,6 @@
 # On 12/01/2017
 core/en/guides/build-device/assertions: /core/en/reference/assertions
 
-# Landscape
-landscape/en/: /landscape/en/landscape-intro
-
 # MAAS
 maas(/|/en/?|/2.1/?)?: /maas/2.1/en/
 maas/2.1/en/installconfig-deploy-nodes: /maas/2.1/en/installconfig-nodes-deploy


### PR DESCRIPTION
QA
--

Run the site (`./run`). Go to <http://127.0.0.1:8007>. Follow link to
landscape docs. See that it is at <http://127.0.0.1:8007/landscape/en/>
instead of a sub-page.