### PR TITLE
Redirect old conjure-up URLs to new

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ env3/
 /static/media/*/
 templates/*/
 docs/
+env2/

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -21,6 +21,10 @@ maas/2.2/en/intel-rsd/?: /maas/2.2/en/nodes-comp-hw
 # conjure-up
 conjure-up(/|/en/?)?: /conjure-up/2.2.0/en/
 
+# conjure-up
+conjure-up(/|/en/?|/2.2.0/?)?: /conjure-up/2.2.0/en/
+conjure-up/en/(?P<page>.+): /conjure-up/2.2.0/en/{page}
+
 # Generic rules
 # ===
 

--- a/run
+++ b/run
@@ -233,8 +233,7 @@ build_docs () {
             versions=""
             source_folder=""
 
-            if [ "$name" == "maas" ]; then versions="--build-version-branches"; fi
-            if [ "$name" == "conjure-up" ]; then versions="--build-version-branches"; fi
+            if [ "$name" == "maas" ] || [ "$name" == "conjure-up" ] ; then versions="--build-version-branches"; fi
             if [ "$name" == "documentation-builder" ]; then source_folder="--source-folder docs"; fi
 
             documentation-builder --base-directory "docs/${name}"  \

--- a/templates/index.html
+++ b/templates/index.html
@@ -46,7 +46,7 @@
                   <td><a href="https://conjure-up.io" class="p-link--external">Conjure-up</a></td>
                   <td>
                       <p>Documentation for Conjure-up.</p>
-                      <p><a href="/conjure-up/2.2.0/en">Read the Conjure-up documentation&nbsp;&rsaquo;</a></p>
+                      <p><a href="/conjure-up/en">Read the Conjure-up documentation&nbsp;&rsaquo;</a></p>
                   </td>
               </tr>
               <tr>


### PR DESCRIPTION
QA
--

`./run clean`
`./run`

Check `http://127.0.0.1:8007/conjure-up/en/walkthrough?_ga=2.50604649.1181177546.1502958538-1953003874.1490003599` redirects through to new page.