### PR TITLE
Make commit_id an env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN pip3 install --upgrade pip && pip3 install gunicorn -r requirements.txt
 
 # Set git commit ID
 ARG COMMIT_ID
+ENV COMMIT_ID=${COMMIT_ID}
 RUN test -n "${COMMIT_ID}"
 
 # Setup commands to run server

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Django==1.11.1
+canonicalwebteam.custom_response_headers==0.2.0
 canonicalwebteam.versioned-static==1.0.1
 django-static-root-finder==0.1
 django-asset-server-url==0.1

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -3,6 +3,8 @@ Django project settings
 """
 
 import os
+import socket
+
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
 # This will set the SECRET_KEY to "no_secret", unless the SECRET_KEY
@@ -51,6 +53,11 @@ WHITENOISE_ALLOW_ALL_ORIGINS = False
 
 ASSET_SERVER_URL = 'https://assets.ubuntu.com/v1/'
 
+CUSTOM_HEADERS = {
+    'X-commit-ID': os.getenv('COMMIT_ID'),
+    'X-Hostname': socket.gethostname()
+}
+
 # See https://docs.djangoproject.com/en/dev/ref/contrib/
 INSTALLED_APPS = [
     'django.contrib.staticfiles',
@@ -58,6 +65,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE_CLASSES = [
+    'canonicalwebteam.custom_response_headers.Middleware',
     'unslashed.middleware.RemoveSlashMiddleware',
 ]
 


### PR DESCRIPTION
Provide the ID of the commit at which point the code was built, as a HTTP header in the response from the docker container.

For production - so we can easily see which version of the code is running on a unit.

QA
--

``` bash
$ docker build --tag docs .  # Check it complains without COMMIT_ID
The command '/bin/sh -c test -n "${COMMIT_ID}"' returned a non-zero code: 1
$ docker build --tag docs --build-arg COMMIT_ID=`git rev-parse HEAD` .  # Build with COMMIT_ID
$ docker run --rm --name docs-throwaway --daemonize --publish 80:80 docs
$ curl -I localhost | grep 'X-'
X-commit-ID: 018f47199c3709e9d0bceb33bef30546ee76e820
X-Hostname: 096dbd5ae462
$ docker kill docs-throwaway
```