### PR TITLE
Remove all references to phone docs

### DIFF
--- a/build-docs.sh
+++ b/build-docs.sh
@@ -115,26 +115,6 @@ build_docs () {
                             --no-link-extensions 
     fi
       
-    # Phone docs
-    folder="build/phone"
-    name="phone"
-    repo_url="https://github.com/ubuntudesign/phone-docs.git"
-
-    if ! up_to_date ${folder} ${repo_url}; then
-      refresh_repo ${folder} ${repo_url} master
-
-      documentation-builder --base-directory "${folder}"  \
-                            --site-root "/${name}/"  \
-                            --output-path "templates/${name}"  \
-                            --output-media-path "static/media/${name}"  \
-                            --search-url "/search"  \
-                            --search-placeholder "Search Phone docs"  \
-                            --search-domain "docs.ubuntu.com/${name}"  \
-                            --media-url "/static/media/${name}"  \
-                            --tag-manager-code "GTM-K92JCQ"  \
-                            --no-link-extensions 
-    fi 
-
     # MAAS docs
     folder="build/maas"
     name="maas"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "build-sass": "node-sass --include-path node_modules static/sass --output static/css && postcss --use autoprefixer --replace static/css/**/*.css && postcss --use cssnano --dir static/css/minified static/css/**/*.css",
     "build": "yarn run build-docs && yarn run build-sass",
     "test": "sass-lint static/**/*.scss --verbose --no-exit",
-    "clean": "rm -rf node_modules yarn-error.log css static/css *.log *.sqlite _site/ build/ .jekyll-metadata .bundle docs/ templates/phone/ templates/landscape/ templates/documentation-builder/ templates/conjure-up/ templates/core/ templates/maas/ static/media"
+    "clean": "rm -rf node_modules yarn-error.log css static/css *.log *.sqlite _site/ build/ .jekyll-metadata .bundle docs/ templates/landscape/ templates/documentation-builder/ templates/conjure-up/ templates/core/ templates/maas/ static/media"
   },
   "dependencies": {
     "sass-lint": "^1.10.2",

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -31,13 +31,13 @@ conjure-up/en/(?P<page>.+): /conjure-up/2.2.0/en/{page}
 # ===
 
 # Redirect project section roots to English language
-(?P<project>(conjure-up|core|documentation-builder|landscape|phone))/?: /{project}/en/
+(?P<project>(conjure-up|core|documentation-builder|landscape))/?: /{project}/en/
 
 # Add slash to language and version folders, and remove "index"
-(?P<project>(conjure-up|core|documentation-builder|landscape|phone))/(?P<language>[a-zA-Z]{2})(/index)?: /{project}/{language}/
+(?P<project>(conjure-up|core|documentation-builder|landscape))/(?P<language>[a-zA-Z]{2})(/index)?: /{project}/{language}/
 
 # Remove trailing slash or .html from document URLs
-(?P<project>(maas|conjure-up|core|documentation-builder|landscape|phone))/(?P<version>[a-zA-Z0-9-\._]+/)?(?P<language>[a-zA-Z]{2})/(?P<document>.*)(/|.html): /{project}/{version}{language}/{document}
+(?P<project>(maas|conjure-up|core|documentation-builder|landscape))/(?P<version>[a-zA-Z0-9-\._]+/)?(?P<language>[a-zA-Z]{2})/(?P<document>.*)(/|.html): /{project}/{version}{language}/{document}
 
 # Pages redirects:
 # On 12/01/2017

--- a/webapp/tests/test_redirects.py
+++ b/webapp/tests/test_redirects.py
@@ -34,22 +34,6 @@ class RedirectCoreTestCase(RedirectTestCase):
         self._assertRedirect('/core/en/test/index.html', self.test_index)
 
 
-class RedirectPhoneTestCase(RedirectTestCase):
-    home = '/phone/en/'
-    test_page = '/phone/en/test'
-    test_index = '/phone/en/test/index'
-
-    def test_redirect_phone_to_en(self):
-        self._assertRedirect('/phone', self.home)
-        self._assertRedirect('/phone/', self.home)
-        self._assertRedirect('/phone/en', self.home)
-        self._assertDoesNotRedirect(self.home)
-
-    def test_redirect_phone_simple_path(self):
-        self._assertRedirect('/phone/en/test/', self.test_page)
-        self._assertRedirect('/phone/en/test/index.html', self.test_index)
-
-
 class RedirectMAASTestCase(RedirectTestCase):
     home = '/maas/2.2/en/'
     test_page = '/maas/2.1/en/test'


### PR DESCRIPTION
Phone docs are now built in their own system, direct from the phone-docs repo,
and https://docs.ubuntu.com/phone is now using that system.

This removes all mention of building phone docs from this repo.

QA
--

``` bash
./run clean
./run
```

Visit <127.0.0.1:8007/phone>, see that it 404s