### PR TITLE
Fix core build by using docs dir

### DIFF
--- a/build-docs.sh
+++ b/build-docs.sh
@@ -61,7 +61,7 @@ build_docs () {
         ../../bin/repo sync -q
       )
 
-      documentation-builder --base-directory "${folder}"  \
+      documentation-builder --base-directory "${folder}/docs"  \
                             --site-root "/${name}/"  \
                             --output-path "templates/${name}"  \
                             --output-media-path "static/media/${name}"  \


### PR DESCRIPTION
The docs have moved to the docs/ inside the core repo. Change the build
script to accommodate.

QA
--

Test the `master` branch with `./run build`. This should break, complaining that there's no `metadata.yaml` when it tried to build core docs.

Now checkout this branch and run `./run build`. This should hopefully succeed, with the core docs looking as they should.