### PR TITLE
Update redirects for maas 2.3

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -2,7 +2,8 @@
 # ===
 
 # MAAS
-maas(/|/en/?)?: /maas/2.2/en/
+maas(/|/en/?|/2.4.0/?)?: /maas/2.3/en/
+maas/en/(?P<page>.+): /maas/2.3/en/{page}
 maas/(?P<version>[0-9-\._]+|devel)(/|/index)?: /maas/{version}/en/
 maas/(?P<version>[0-9-\._]+|devel)/(?P<language>[a-zA-Z]{2})(/index)?: /maas/{version}/{language}/
 maas/devel/en/intel-rsd/?: /maas/devel/en/nodes-comp-hw
@@ -19,9 +20,6 @@ maas/2.2/en/installconfig-commisson-nodes/?: /maas/2.2/en/nodes-commission
 maas/2.2/en/installconfig-nodes-deploy/?: /maas/2.2/en/nodes-deploy
 maas/2.2/en/installconfig-nodes-power-types/?: /maas/2.2/en/nodes-power-types
 maas/2.2/en/intel-rsd/?: /maas/2.2/en/nodes-comp-hw
-
-# conjure-up
-conjure-up(/|/en/?)?: /conjure-up/2.4.0/en/
 
 # conjure-up
 conjure-up(/|/en/?|/2.4.0/?)?: /conjure-up/2.4.0/en/

--- a/webapp/tests/test_redirects.py
+++ b/webapp/tests/test_redirects.py
@@ -35,9 +35,9 @@ class RedirectCoreTestCase(RedirectTestCase):
 
 
 class RedirectMAASTestCase(RedirectTestCase):
-    home = '/maas/2.2/en/'
+    home = '/maas/2.3/en/'
     test_page = '/maas/2.1/en/test'
-    test_index = '/maas/2.2/en/test/index'
+    test_index = '/maas/2.3/en/test/index'
 
     def test_does_not_redirect_maas_root_path(self):
         self._assertDoesNotRedirect(self.home)
@@ -45,9 +45,9 @@ class RedirectMAASTestCase(RedirectTestCase):
     def test_redirect_maas_to_en_with_version(self):
         self._assertRedirect('/maas', self.home)
         self._assertRedirect('/maas/', self.home)
-        self._assertRedirect('/maas/2.2', self.home)
-        self._assertRedirect('/maas/2.2/', self.home)
-        self._assertRedirect('/maas/2.2/en', self.home)
+        self._assertRedirect('/maas/2.3', self.home)
+        self._assertRedirect('/maas/2.3/', self.home)
+        self._assertRedirect('/maas/2.3/en', self.home)
         self._assertRedirect('/maas/en', self.home)
         self._assertRedirect('/maas/en/', self.home)
 
@@ -57,4 +57,4 @@ class RedirectMAASTestCase(RedirectTestCase):
 
     def test_redirect_maas_simple_path(self):
         self._assertRedirect('/maas/2.1/en/test/', self.test_page)
-        self._assertRedirect('/maas/2.2/en/test/index.html', self.test_index)
+        self._assertRedirect('/maas/2.3/en/test/index.html', self.test_index)


### PR DESCRIPTION
Sure up the redirects, and update Maas redirects to point to version 2.3

QA
--

``` bash
./run
```

Now go to <http://localhost:8007/maas>, <http://localhost:8007/maas/en/>, <http://localhost:8007/maas/2.3/> and check you end up on the homepage.

Go to <http://localhost:8007/maas/en/intro-concepts>, and check you end up at <https://docs.ubuntu.com/maas/2.3/en/intro-concepts>