### PR TITLE
conjure-up and maas removal / redirections

### DIFF
--- a/build-docs.sh
+++ b/build-docs.sh
@@ -45,27 +45,6 @@ up_to_date() {
 build_docs () {
     mkdir -p build
 
-    # Conjure-up docs
-    folder="build/conjure-up"
-    name="conjure-up"
-    repo_url="https://github.com/canonicalltd/docs-conjure-up.git"
-
-    if ! up_to_date ${folder} ${repo_url}; then
-      refresh_repo ${folder} ${repo_url} master
-
-      documentation-builder --base-directory "${folder}"  \
-                            --site-root "/${name}/"  \
-                            --output-path "templates/${name}"  \
-                            --output-media-path "static/media/${name}"  \
-                            --search-url "/search"  \
-                            --search-placeholder "Search ${name} docs"  \
-                            --search-domain "docs.ubuntu.com/${name}"  \
-                            --build-version-branches  \
-                            --media-url "/static/media/${name}"  \
-                            --tag-manager-code "GTM-K92JCQ"  \
-                            --no-link-extensions
-    fi
-
     # Documentation-builder
     folder="build/documentation-builder"
     name="documentation-builder"

--- a/build-docs.sh
+++ b/build-docs.sh
@@ -87,27 +87,6 @@ build_docs () {
                             --no-link-extensions
     fi
 
-    # MAAS docs
-    folder="build/maas"
-    name="maas"
-    repo_url="https://github.com/canonicalltd/maas-docs.git"
-
-    if ! up_to_date ${folder} ${repo_url}; then
-      refresh_repo ${folder} ${repo_url} master
-
-      documentation-builder --base-directory "${folder}"  \
-                            --site-root "/${name}/"  \
-                            --output-path "templates/${name}"  \
-                            --output-media-path "static/media/${name}"  \
-                            --search-url "/search"  \
-                            --search-placeholder "Search MAAS docs"  \
-                            --search-domain "docs.ubuntu.com/${name}"  \
-                            --build-version-branches  \
-                            --media-url "/static/media/${name}"  \
-                            --tag-manager-code "GTM-K92JCQ"  \
-                            --no-link-extensions
-    fi
-
     # Style Guide docs
     folder="build/styleguide"
     name="styleguide"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "build-sass": "node-sass --include-path node_modules static/sass --output static/css && postcss --use autoprefixer --replace static/css/**/*.css && postcss --use cssnano --dir static/css/minified static/css/**/*.css",
     "build": "yarn run build-docs && yarn run build-sass",
     "test": "sass-lint static/**/*.scss --verbose --no-exit",
-    "clean": "rm -rf node_modules yarn-error.log css static/css *.log *.sqlite _site/ build/ .jekyll-metadata .bundle docs/ templates/landscape/ templates/documentation-builder/ templates/conjure-up/ templates/maas/ static/media"
+    "clean": "rm -rf node_modules yarn-error.log css static/css *.log *.sqlite _site/ build/ .jekyll-metadata .bundle docs/ templates/landscape/ templates/documentation-builder/ templates/conjure-up/ static/media"
   },
   "dependencies": {
     "sass-lint": "^1.10.2",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "build-sass": "node-sass --include-path node_modules static/sass --output static/css && postcss --use autoprefixer --replace static/css/**/*.css && postcss --use cssnano --dir static/css/minified static/css/**/*.css",
     "build": "yarn run build-docs && yarn run build-sass",
     "test": "sass-lint static/**/*.scss --verbose --no-exit",
-    "clean": "rm -rf node_modules yarn-error.log css static/css *.log *.sqlite _site/ build/ .jekyll-metadata .bundle docs/ templates/landscape/ templates/documentation-builder/ templates/conjure-up/ static/media"
+    "clean": "rm -rf node_modules yarn-error.log css static/css *.log *.sqlite _site/ build/ .jekyll-metadata .bundle docs/ templates/landscape/ templates/documentation-builder/ static/media"
   },
   "dependencies": {
     "sass-lint": "^1.10.2",

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -2,24 +2,8 @@
 # ===
 
 # MAAS
-maas(/|/en/?|/2.4.0/?)?: /maas/2.3/en/
-maas/en/(?P<page>.+): /maas/2.3/en/{page}
-maas/(?P<version>[0-9-\._]+|devel)(/|/index)?: /maas/{version}/en/
-maas/(?P<version>[0-9-\._]+|devel)/(?P<language>[a-zA-Z]{2})(/index)?: /maas/{version}/{language}/
-maas/devel/en/intel-rsd/?: /maas/devel/en/nodes-comp-hw
-maas/2.1/en/installconfig-deploy-nodes/?: /maas/2.1/en/installconfig-nodes-deploy
-maas/2.1/en/installconfig-gui/?: /maas/2.1/en/installconfig-webui
-maas/2.1/en/installconfig-hwe-kernels/?: /maas/2.1/en/installconfig-nodes-ubuntu-kernels
-maas/2.1/en/installconfig-kernel/?: /maas/2.1/en/installconfig-nodes-kernel-boot-options
-maas/2.1/en/installconfig-server-iso/?: /maas/2.1/en/installconfig-iso-install
-maas/2.1/en/installconfig-commisson-nodes/?: /maas/2.1/en/nodes-commission
-maas/2.1/en/installconfig-add-nodes/?: /maas/2.1/en/nodes-add
-maas/2.2/en/installconfig-nodes-hw-testing/?: /maas/2.2/en/nodes-hw-testing
-maas/2.2/en/installconfig-add-nodes/?: /maas/2.2/en/nodes-add
-maas/2.2/en/installconfig-commisson-nodes/?: /maas/2.2/en/nodes-commission
-maas/2.2/en/installconfig-nodes-deploy/?: /maas/2.2/en/nodes-deploy
-maas/2.2/en/installconfig-nodes-power-types/?: /maas/2.2/en/nodes-power-types
-maas/2.2/en/intel-rsd/?: /maas/2.2/en/nodes-comp-hw
+maas: https://docs.maas.io/
+maas/(?P<page>.+): https://docs.maas.io/{page}
 
 # conjure-up
 conjure-up(/|/en/?|/2.4.0/?)?: /conjure-up/2.4.0/en/
@@ -35,4 +19,4 @@ conjure-up/en/(?P<page>.+): /conjure-up/2.4.0/en/{page}
 (?P<project>(conjure-up|documentation-builder|landscape))/(?P<language>[a-zA-Z]{2})(/index)?: /{project}/{language}/
 
 # Remove trailing slash or .html from document URLs
-(?P<project>(maas|conjure-up|documentation-builder|landscape))/(?P<version>[a-zA-Z0-9-\._]+/)?(?P<language>[a-zA-Z]{2})/(?P<document>.*)(/|.html): /{project}/{version}{language}/{document}
+(?P<project>(conjure-up|documentation-builder|landscape))/(?P<version>[a-zA-Z0-9-\._]+/)?(?P<language>[a-zA-Z]{2})/(?P<document>.*)(/|.html): /{project}/{version}{language}/{document}

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -6,17 +6,17 @@ maas: https://docs.maas.io/
 maas/(?P<page>.+): https://docs.maas.io/{page}
 
 # conjure-up
-conjure-up(/|/en/?|/2.4.0/?)?: /conjure-up/2.4.0/en/
-conjure-up/en/(?P<page>.+): /conjure-up/2.4.0/en/{page}
+conjure-up: https://docs.conjure-up.io/
+conjure-up/(?P<page>.+): https://docs.conjure-up.io/{page}
 
 # Generic rules
 # ===
 
 # Redirect project section roots to English language
-(?P<project>(conjure-up|documentation-builder|landscape))/?: /{project}/en/
+(?P<project>(documentation-builder|landscape))/?: /{project}/en/
 
 # Add slash to language and version folders, and remove "index"
-(?P<project>(conjure-up|documentation-builder|landscape))/(?P<language>[a-zA-Z]{2})(/index)?: /{project}/{language}/
+(?P<project>(documentation-builder|landscape))/(?P<language>[a-zA-Z]{2})(/index)?: /{project}/{language}/
 
 # Remove trailing slash or .html from document URLs
-(?P<project>(conjure-up|documentation-builder|landscape))/(?P<version>[a-zA-Z0-9-\._]+/)?(?P<language>[a-zA-Z]{2})/(?P<document>.*)(/|.html): /{project}/{version}{language}/{document}
+(?P<project>(documentation-builder|landscape))/(?P<version>[a-zA-Z0-9-\._]+/)?(?P<language>[a-zA-Z]{2})/(?P<document>.*)(/|.html): /{project}/{version}{language}/{document}

--- a/templates/index.html
+++ b/templates/index.html
@@ -32,7 +32,7 @@
                   <td><a href="https://maas.io" class="p-link--external">MAAS</a></td>
                   <td>
                       <p>Documentation for MAAS (Metal as a Service).</p>
-                      <p><a href="/maas/2.3/en/">Read the MAAS documentation&nbsp;&rsaquo;</a></p>
+                      <p><a href="https://docs.maas.io/2.3/en/">Read the MAAS documentation&nbsp;&rsaquo;</a></p>
                   </td>
               </tr>
               <tr>

--- a/templates/index.html
+++ b/templates/index.html
@@ -46,7 +46,7 @@
                   <td><a href="https://conjure-up.io" class="p-link--external">Conjure-up</a></td>
                   <td>
                       <p>Documentation for Conjure-up.</p>
-                      <p><a href="/conjure-up/en">Read the Conjure-up documentation&nbsp;&rsaquo;</a></p>
+                      <p><a href="https://docs.conjure-up.io/en">Read the Conjure-up documentation&nbsp;&rsaquo;</a></p>
                   </td>
               </tr>
               <tr>

--- a/webapp/tests/test_redirects.py
+++ b/webapp/tests/test_redirects.py
@@ -12,29 +12,3 @@ class RedirectTestCase(SimpleTestCase):
     def _assertDoesNotRedirect(self, requested):
         response = self.client.get(requested)
         self.assertTrue(response.status_code not in [301, 302])
-
-
-class RedirectMAASTestCase(RedirectTestCase):
-    home = '/maas/2.3/en/'
-    test_page = '/maas/2.1/en/test'
-    test_index = '/maas/2.3/en/test/index'
-
-    def test_does_not_redirect_maas_root_path(self):
-        self._assertDoesNotRedirect(self.home)
-
-    def test_redirect_maas_to_en_with_version(self):
-        self._assertRedirect('/maas', self.home)
-        self._assertRedirect('/maas/', self.home)
-        self._assertRedirect('/maas/2.3', self.home)
-        self._assertRedirect('/maas/2.3/', self.home)
-        self._assertRedirect('/maas/2.3/en', self.home)
-        self._assertRedirect('/maas/en', self.home)
-        self._assertRedirect('/maas/en/', self.home)
-
-    def test_does_not_redirect_maas_simple_path(self):
-        self._assertDoesNotRedirect(self.test_page)
-        self._assertDoesNotRedirect(self.test_index)
-
-    def test_redirect_maas_simple_path(self):
-        self._assertRedirect('/maas/2.1/en/test/', self.test_page)
-        self._assertRedirect('/maas/2.3/en/test/index.html', self.test_index)


### PR DESCRIPTION
## Done

Please do review but do not merge just yet.

Remove docs build for `/conjure-up` and `maas`, and redirect to new domains.

## QA

- `./run`
- `curl -I http://0.0.0.0:8007/conjure-up/testing`  should redirect to docs.conjure-up.io and preserve the `/testing` path.
- `curl -I http://0.0.0.0:8007/maas/testing`  should redirect to docs.maas.io and preserve the `/testing` path.
- Visit http://0.0.0.0:8007/ and make sure it is error free. http://0.0.0.0:8007/documentation-builder/en/ should show the documentation builder docs.

Feel free to try some other paths for the redirect testing steps.