### PR TITLE
Stop hardcoding  docs versions in the html

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -40,7 +40,7 @@
             <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/0de4fcd5-logo-maas-icon.svg" alt="Icon">
           </a>
           <div class="p-matrix__content">
-            <h4 class="p-matrix__title"><a class="p-link" href="https://docs.maas.io/2.3/en/">MAAS&nbsp;</a></h4>
+            <h4 class="p-matrix__title"><a class="p-link" href="https://docs.maas.io/">MAAS&nbsp;</a></h4>
             <p class="p-matrix__desc">Create a bare-metal cloud with Metal as a Service for IPAM and provisioning</p>
           </div>
         </li>
@@ -81,7 +81,7 @@
           </div>
         </li>
         <li class="p-matrix__item">
-          <a href="https://docs.conjure-up.io/2.4.0/en/">
+          <a href="https://docs.conjure-up.io/">
             <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/c5cb0f8e-picto-ubuntu.svg" alt="Icon">
           </a>
           <div class="p-matrix__content">

--- a/templates/index.html
+++ b/templates/index.html
@@ -36,7 +36,7 @@
     <div class="row">
       <ul class="p-matrix">
         <li class="p-matrix__item">
-          <a href="https://docs.maas.io/2.3/en/">
+          <a href="https://docs.maas.io/">
             <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/0de4fcd5-logo-maas-icon.svg" alt="Icon">
           </a>
           <div class="p-matrix__content">
@@ -85,7 +85,7 @@
             <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/c5cb0f8e-picto-ubuntu.svg" alt="Icon">
           </a>
           <div class="p-matrix__content">
-            <h4 class="p-matrix__title"><a class="p-link" href="https://docs.conjure-up.io/2.4.0/en/">Conjure-up&nbsp;</a></h4>
+            <h4 class="p-matrix__title"><a class="p-link" href="https://docs.conjure-up.io/">Conjure-up&nbsp;</a></h4>
             <p class="p-matrix__desc">Use conjure-up to get you a fully installed and usable stack</p>
           </div>
         </li>


### PR DESCRIPTION
Conjure-up and maas docs sites can handle redirects to the defaults without hardcoding a version in the HTML here.

## Done

remove specific version for MAAS docs link
remove specific version for conjure-up docs link

## QA

see that the new links resolve to the correct default versions

