### PR TITLE
Add meta description to the head of the layout

### DIFF
--- a/templates/includes/layout.html
+++ b/templates/includes/layout.html
@@ -18,6 +18,7 @@
   <link rel="icon" href="{{ ASSET_SERVER_URL }}8d4630a6-pictogram-heart-mid-grey.svg">
   <title>Ubuntu documentation</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="The docs directory for all Ubuntu operating systems and products." />
   <link rel="stylesheet" href="{% versioned_static 'css/main.css' %}" />
 </head>
 


### PR DESCRIPTION
## Done
Added the meta description to the head of the layout template.

## QA
- Go to any page and view-source
- Check there is a meta description
- Check the description matches the [copy doc](https://docs.google.com/document/d/1mcfPYByoIT_iFOot6fxqq_bXX9p9vENWkLt4-ZI22Qg/edit)

## Issue / Card
https://github.com/canonical-websites/docs.ubuntu.com/issues/164