### PR TITLE
fixed typos on docs.u.c homepage

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -178,7 +178,7 @@
         </div>
         <div class="col-6">
           <h3><a href="https://github.com/canonical-webteam/documentation-builder">Documentation builder&nbsp;&rsaquo;</a></h3>
-          <p>A tool for generating documentation HTML from Markdown in the standard Canonical format</p>
+          <p>A tool for generating documentation HTML from Markdown in the standard Canonical format.</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Done

- fixed spelling of prov*i*des
- added a full stop

## QA

- ./run
- <http://0.0.0.0:8007>
- compare to the [copy doc](https://docs.google.com/document/d/1mcfPYByoIT_iFOot6fxqq_bXX9p9vENWkLt4-ZI22Qg/edit#heading=h.7gsn9t3mksj3)

## Screenshots

![image](https://user-images.githubusercontent.com/441217/43457710-9a343c8e-94bf-11e8-8e9c-4eb0505c7b45.png)
