### PR TITLE
Rename docs from snap-enterprise-proxy to snap-store-proxy

### DIFF
--- a/build-docs.sh
+++ b/build-docs.sh
@@ -106,9 +106,9 @@ build_docs () {
                             --no-link-extensions
     fi
 
-    # Snap Enterprise Proxy docs
-    folder="build/snap-enterprise-proxy"
-    name="snap-enterprise-proxy"
+    # Snap Store Proxy docs
+    folder="build/snap-store-proxy"
+    name="snap-store-proxy"
     repo_url="https://github.com/canonical-ols/snapstore-snap-docs.git"
 
     if ! up_to_date ${folder} ${repo_url}; then
@@ -119,7 +119,7 @@ build_docs () {
                             --output-path "templates/${name}"  \
                             --output-media-path "static/media/${name}"  \
                             --search-url "/search"  \
-                            --search-placeholder "Search Snap Enterprise Proxy docs"  \
+                            --search-placeholder "Search Snap Store Proxy docs"  \
                             --search-domain "docs.ubuntu.com/${name}"  \
                             --media-url "/static/media/${name}"  \
                             --tag-manager-code "GTM-K92JCQ"  \

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -9,14 +9,18 @@ maas/(?P<page>.+): https://docs.maas.io/{page}
 conjure-up: https://docs.conjure-up.io/
 conjure-up/(?P<page>.+): https://docs.conjure-up.io/{page}
 
+# snap-store-proxy
+snap-enterprise-proxy: /snap-store-proxy
+snap-enterprise-proxy/(?P<page>.+): /snap-store-proxy/{page}
+
 # Generic rules
 # ===
 
 # Redirect project section roots to English language
-(?P<project>(documentation-builder|landscape|snap-enterprise-proxy))/?: /{project}/en/
+(?P<project>(documentation-builder|landscape|snap-store-proxy))/?: /{project}/en/
 
 # Add slash to language and version folders, and remove "index"
-(?P<project>(documentation-builder|landscape|snap-enterprise-proxy))/(?P<language>[a-zA-Z]{2})(/index)?: /{project}/{language}/
+(?P<project>(documentation-builder|landscape|snap-store-proxy))/(?P<language>[a-zA-Z]{2})(/index)?: /{project}/{language}/
 
 # Remove trailing slash or .html from document URLs
-(?P<project>(documentation-builder|landscape|snap-enterprise-proxy))/(?P<version>[a-zA-Z0-9-\._]+/)?(?P<language>[a-zA-Z]{2})/(?P<document>.*)(/|.html): /{project}/{version}{language}/{document}
+(?P<project>(documentation-builder|landscape|snap-store-proxy))/(?P<version>[a-zA-Z0-9-\._]+/)?(?P<language>[a-zA-Z]{2})/(?P<document>.*)(/|.html): /{project}/{version}{language}/{document}

--- a/templates/index.html
+++ b/templates/index.html
@@ -117,12 +117,12 @@
           </div>
         </li>
         <li class="p-matrix__item">
-          <a href="/snap-enterprise-proxy/en">
+          <a href="/snap-store-proxy/en">
             <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/1570841c-icon-app-store.svg" alt="Icon">
           </a>
           <div class="p-matrix__content">
-            <h4 class="p-matrix__title"><a class="p-link" href="/snap-enterprise-proxy/en">Snap Enterprise&nbsp;</a></h4>
-            <p class="p-matrix__desc">The Snap Enterprise Proxy provdes a means to access the Snap Store for devices with restricted network access</p>
+            <h4 class="p-matrix__title"><a class="p-link" href="/snap-store-proxy/en">Snap Store Proxy&nbsp;</a></h4>
+            <p class="p-matrix__desc">The Snap Store Proxy provdes an on-premise edge proxy to the Snap Store for your devices</p>
           </div>
         </li>
         <li class="p-matrix__item u-hide--small">&nbsp;</li>

--- a/templates/index.html
+++ b/templates/index.html
@@ -122,7 +122,7 @@
           </a>
           <div class="p-matrix__content">
             <h4 class="p-matrix__title"><a class="p-link" href="/snap-store-proxy/en">Snap Store Proxy&nbsp;</a></h4>
-            <p class="p-matrix__desc">The Snap Store Proxy provdes an on-premise edge proxy to the Snap Store for your devices</p>
+            <p class="p-matrix__desc">The Snap Store Proxy provides an on-premise edge proxy to the Snap Store for your devices</p>
           </div>
         </li>
         <li class="p-matrix__item u-hide--small">&nbsp;</li>


### PR DESCRIPTION
## Done

- Rename docs from snap-enterprise-proxy to snap-store-proxy
- Add redirect from former to latter

## QA

- Verify redirects from /snap-enterprise-proxy/* to /snap-store-proxy/*

## Issue / Card

## Screenshots