### PR TITLE
Add entrypoint for talisker gevent workers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build final image
-FROM ubuntu:xenial
+FROM ubuntu:bionic
 
 # Import code, install code dependencies
 WORKDIR /srv
@@ -10,14 +10,14 @@ RUN apt-get update && apt-get install --yes python3-pip
 
 # Python dependencies
 ENV LANG C.UTF-8
-RUN pip3 install gunicorn -r requirements.txt
+RUN pip3 install -r requirements.txt
 
 # Set git commit ID
 ARG COMMIT_ID
-ENV COMMIT_ID=${COMMIT_ID}
 RUN test -n "${COMMIT_ID}"
+RUN echo "${COMMIT_ID}" > version-info.txt
 
 # Setup commands to run server
 EXPOSE 80
-ENTRYPOINT ["talisker.gunicorn", "webapp.wsgi", "--access-logfile", "-", "--error-logfile", "-", "--bind"]
+ENTRYPOINT ["./entrypoint"]
 CMD ["0.0.0.0:80"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,14 @@
-# Build final image
 FROM ubuntu:bionic
 
-# Import code, install code dependencies
+# Set up environment
+ENV LANG C.UTF-8
 WORKDIR /srv
-ADD . /srv
 
 # System dependencies
 RUN apt-get update && apt-get install --yes python3-pip
 
-# Python dependencies
-ENV LANG C.UTF-8
+# Import code, install code dependencies
+ADD . .
 RUN pip3 install -r requirements.txt
 
 # Set git commit ID
@@ -18,6 +17,6 @@ RUN test -n "${COMMIT_ID}"
 RUN echo "${COMMIT_ID}" > version-info.txt
 
 # Setup commands to run server
-EXPOSE 80
 ENTRYPOINT ["./entrypoint"]
 CMD ["0.0.0.0:80"]
+

--- a/entrypoint
+++ b/entrypoint
@@ -2,5 +2,5 @@
 
 set -e
 
-talisker.gunicorn.gevent webapp.wsgi --reload --log-level debug --timeout 9999 --access-logfile - --worker-class gevent --error-logfile - --bind $1
+talisker.gunicorn.gevent webapp.wsgi --reload --log-level debug --timeout 9999 --access-logfile - --workers 3 --worker-class gevent --error-logfile - --bind $1
 

--- a/entrypoint
+++ b/entrypoint
@@ -1,0 +1,6 @@
+#! /usr/bin/env bash
+
+set -e
+
+talisker.gunicorn.gevent webapp.wsgi --reload --log-level debug --timeout 9999 --access-logfile - --worker-class gevent --error-logfile - --bind $1
+

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "build-docs": "./build-docs.sh",
     "build-sass": "node-sass --include-path node_modules static/sass --output static/css && postcss --use autoprefixer --replace static/css/**/*.css && postcss --use cssnano --dir static/css/minified static/css/**/*.css",
     "build": "yarn run build-docs && yarn run build-sass",
-    "serve": "talisker.gunicorn webapp.wsgi --reload --log-level debug --timeout 9999 --access-logfile - --error-logfile - --bind 0.0.0.0:${PORT}",
+    "serve": "./entrypoint 0.0.0.0:${PORT}",
     "test": "sass-lint static/**/*.scss --verbose --no-exit",
     "clean": "rm -rf node_modules yarn-error.log css static/css *.log *.sqlite _site/ build/ .jekyll-metadata .bundle docs/ templates/landscape/ templates/documentation-builder/ static/media"
   },

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ django-template-finder-view==0.2
 django-unslashed==0.3.0
 django-yaml-redirects==0.5.4
 canonicalwebteam.gsa==2.0.1
-talisker==0.9.7
+talisker==0.9.13
+gunicorn[gevent]
 whitenoise==3.3.0
 ubuntudesign.documentation-builder==1.5.1


### PR DESCRIPTION
Fixes https://github.com/ubuntudesign/base-squad/issues/98

QA
--

``` bash
./run
```

See that it mentions "Booting worker" 3 times. Go to http://localhost:8007 - browse around, check the site works. Then:

``` bash
docker build --tag docs --build-arg COMMIT_ID=`git rev-parse HEAD` .
docker run -ti -p 8099:80 docs
```

Go to http://localhost:8099 - similarly, see that it mentions "Booting worker" 3 times and check the site works.

Also, check the `X-VCS-Revision` shows correctly:

``` bash
$ curl -Is localhost:8099 | grep VCS
X-VCS-Revision: {commit_hash}
```