### PR TITLE
Bump documentation-builder to 1.6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ canonicalwebteam.gsa==2.0.1
 talisker==0.9.13
 gunicorn[gevent]
 whitenoise==3.3.0
-ubuntudesign.documentation-builder==1.5.1
+ubuntudesign.documentation-builder==1.6.0


### PR DESCRIPTION
## Done

* Bump documentation-builder to 1.6.0

## QA

* See that site-wide-footer links are respected in /snap-store-proxy/en

## Issue / Card
Fixes #170 
## Screenshots