### PR TITLE
Use a larger snapcraft logo

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -55,7 +55,7 @@
         </li>
         <li class="p-matrix__item">
           <a href="https://docs.snapcraft.io">
-            <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/25302166-snapcraft-primary-icon--dark.svg" alt="Icon">
+            <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/19c7461a-snapcraft-primary-icon--dark.svg" alt="Icon">
           </a>
           <div class="p-matrix__content">
             <h4 class="p-matrix__title"><a class="p-link" href="https://docs.snapcraft.io">Snapcraft&nbsp;</a></h4>


### PR DESCRIPTION
## Done

 * Uploaded a bigger 'native' SVG to asset server
 * Referenced it from index.html

## QA

 * Is the snapcraft logo the same size as the other ones?

## Issue / Card
 * Fixes #175
## Screenshots

![](https://screenshotscdn.firefoxusercontent.com/images/e4b2a211-3389-4d6e-94f8-08371458ab25.png)


