### PR TITLE
Fix redirects to also handle trailing slashes

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -3,15 +3,15 @@
 
 # MAAS
 maas: https://docs.maas.io/
-maas/(?P<page>.+): https://docs.maas.io/{page}
+maas/(?P<page>.*): https://docs.maas.io/{page}
 
 # conjure-up
 conjure-up: https://docs.conjure-up.io/
-conjure-up/(?P<page>.+): https://docs.conjure-up.io/{page}
+conjure-up/(?P<page>.*): https://docs.conjure-up.io/{page}
 
 # snap-store-proxy
-snap-enterprise-proxy: /snap-store-proxy
-snap-enterprise-proxy/(?P<page>.+): /snap-store-proxy/{page}
+snap-enterprise-proxy: /snap-store-proxy/en/
+snap-enterprise-proxy/(?P<page>.*): /snap-store-proxy/{page}
 
 # Generic rules
 # ===


### PR DESCRIPTION
## Done

* Change all redirects to accept empty pages, thereby coping with trailing slash
* Add /en to the snap-enterprise-proxy redirect, to avoid two redirects.

## QA

* Visit /snap-enterprise-proxy/ ; /maas/ ; /conjure-up/ and verify you're redirected.

## Issue / Card

Fixes #178

## Screenshots

N/A