### PR TITLE
Redirect searches to https://www.ubuntu.com/search

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -24,3 +24,6 @@ snap-enterprise-proxy/(?P<page>.*): /snap-store-proxy/{page}
 
 # Remove trailing slash or .html from document URLs
 (?P<project>(documentation-builder|landscape|snap-store-proxy))/(?P<version>[a-zA-Z0-9-\._]+/)?(?P<language>[a-zA-Z]{2})/(?P<document>.*)(/|.html): /{project}/{version}{language}/{document}
+
+# Redirect to www.ubuntu.com search
+search/?$: https://www.ubuntu.com/search

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 Django==1.11.16
 canonicalwebteam.custom_response_headers==0.2.0
 canonicalwebteam.versioned-static==1.0.1
+canonicalwebteam.yaml-responses==1.1.0
 django-static-root-finder==0.1
 django-asset-server-url==0.1
 django-template-finder-view==0.2
 django-unslashed==0.3.0
 django-yaml-redirects==0.5.4
-canonicalwebteam.gsa==2.0.1
 statsd<3.3.0
 prometheus_client==0.3.1
 talisker==0.9.16

--- a/webapp/urls.py
+++ b/webapp/urls.py
@@ -1,18 +1,18 @@
 # Modules
 from django.conf.urls import url
-from django_yaml_redirects import load_redirects
 from django_template_finder_view import TemplateFinder
-from canonicalwebteam.gsa.views import SearchView
+from canonicalwebteam.yaml_responses.django_helpers import (
+    create_redirect_views
+)
 
 # Local
 from webapp.views import custom_404, custom_500
 
 # Match any redirects first
-urlpatterns = load_redirects()
+urlpatterns = create_redirect_views()
 
 # Try to find templates
 urlpatterns += [
-    url(r'^search/?$', SearchView.as_view(template_name='search.html')),
     url(r'^(?P<template>.*)/?$', TemplateFinder.as_view())
 ]
 


### PR DESCRIPTION
## Done

Made search redirect to https://www.ubuntu.com/search

## QA

- Run `./run`
- Access `http://0.0.0.0:8007/search?q=https&domain=docs.ubuntu.com`
- Verify you were redirected to `https://www.ubuntu.com/search?q=https&domain=docs.ubuntu.com`

## Issue / Card

Fixes #183 
