### PR TITLE
Landscape - We're ready to make the new site public / more visible

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -72,11 +72,11 @@
           </div>
         </li>
         <li class="p-matrix__item">
-          <a href="https://landscape.canonical.com/static/doc/user-guide/">
+          <a href="https://docs.ubuntu.com/landscape/en/">
             <img class="p-matrix__img" src="https://assets.ubuntu.com/v1/4964d639-landscape-logo.svg" alt="Icon">
           </a>
           <div class="p-matrix__content">
-            <h4 class="p-matrix__title"><a class="p-link" href="https://landscape.canonical.com/static/doc/user-guide/">Landscape&nbsp;</a></h4>
+            <h4 class="p-matrix__title"><a class="p-link" href="https://docs.ubuntu.com/landscape/en/">Landscape&nbsp;</a></h4>
             <p class="p-matrix__desc">Systems management for Ubuntu - updates, package management, repositories, security</p>
           </div>
         </li>


### PR DESCRIPTION
This links to the new main Landscape docs site at docs.ubuntu.com/landscape/en/

The only reason to reject is if I made a silly mistake or if we want to change where it lives first aka #110 

## Done

[List of work items including drive-bys]

## QA

Confirm that docs.ubuntu.com's landscape links point to docs.ubuntu.com/landscape/en/
