### PR TITLE
Remove and redirect /documentation-builder

### DIFF
--- a/build-docs.sh
+++ b/build-docs.sh
@@ -45,27 +45,6 @@ up_to_date() {
 build_docs () {
     mkdir -p build
 
-    # Documentation-builder
-    folder="build/documentation-builder"
-    name="documentation-builder"
-    repo_url="https://github.com/canonical-webteam/documentation-builder.git"
-
-    if ! up_to_date ${folder} ${repo_url}; then
-      refresh_repo ${folder} ${repo_url} master
-
-      documentation-builder --base-directory "${folder}"  \
-                            --site-root "/${name}/"  \
-                            --output-path "templates/${name}"  \
-                            --output-media-path "static/media/${name}"  \
-                            --search-url "/search"  \
-                            --search-placeholder "Search Builder docs"  \
-                            --search-domain "docs.ubuntu.com/${name}"  \
-                            --source-folder docs  \
-                            --media-url "/static/media/${name}"  \
-                            --tag-manager-code "GTM-K92JCQ"  \
-                            --no-link-extensions
-    fi
-
     # Style Guide docs
     folder="build/styleguide"
     name="styleguide"

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -13,17 +13,22 @@ conjure-up/(?P<page>.*): https://docs.conjure-up.io/{page}
 snap-enterprise-proxy: /snap-store-proxy/en/
 snap-enterprise-proxy/(?P<page>.*): /snap-store-proxy/{page}
 
+# Documentation-builder
+documentation-builder/?: https://github.com/canonical-webteam/documentation-builder/tree/master/docs
+documentation-builder/(?P<page>.*)/: https://github.com/canonical-webteam/documentation-builder/tree/master/docs/{page}
+documentation-builder/(?P<page>.*[^/])?(.html)?: https://github.com/canonical-webteam/documentation-builder/tree/master/docs/{page}.md
+
 # Generic rules
 # ===
 
 # Redirect project section roots to English language
-(?P<project>(documentation-builder|landscape|snap-store-proxy))/?: /{project}/en/
+(?P<project>(landscape|snap-store-proxy))/?: /{project}/en/
 
 # Add slash to language and version folders, and remove "index"
-(?P<project>(documentation-builder|landscape|snap-store-proxy))/(?P<language>[a-zA-Z]{2})(/index)?: /{project}/{language}/
+(?P<project>(landscape|snap-store-proxy))/(?P<language>[a-zA-Z]{2})(/index)?: /{project}/{language}/
 
 # Remove trailing slash or .html from document URLs
-(?P<project>(documentation-builder|landscape|snap-store-proxy))/(?P<version>[a-zA-Z0-9-\._]+/)?(?P<language>[a-zA-Z]{2})/(?P<document>.*)(/|.html): /{project}/{version}{language}/{document}
+(?P<project>(landscape|snap-store-proxy))/(?P<version>[a-zA-Z0-9-\._]+/)?(?P<language>[a-zA-Z]{2})/(?P<document>.*)(/|.html): /{project}/{version}{language}/{document}
 
 # Redirect to www.ubuntu.com search
 search/?$: https://www.ubuntu.com/search

--- a/templates/index.html
+++ b/templates/index.html
@@ -176,10 +176,6 @@
           <h3><a href="https://docs.ubuntu.com/styleguide/en">Style guide&nbsp;&rsaquo;</a></h3>
           <p>A guide to the language and style conventions used for Canonical documentation projects.</p>
         </div>
-        <div class="col-6">
-          <h3><a href="https://github.com/canonical-webteam/documentation-builder">Documentation builder&nbsp;&rsaquo;</a></h3>
-          <p>A tool for generating documentation HTML from Markdown in the standard Canonical format.</p>
-        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Because documentation-builder is deprecated and no longer the recommended way to create documentation websites,
we shouldn't elevate its documentation by creating a website for it.

Instead, we'll now simply redirect the user to read the docs directly in the (deprecated) project repository.

QA
--

`./run`

Try going to:

- http://0.0.0.0:8007/ - check the homepage still works
- http://0.0.0.0:8007/documentation-builder
- http://0.0.0.0:8007/documentation-builder/en/
- http://0.0.0.0:8007/documentation-builder/en/structure
- http://0.0.0.0:8007/documentation-builder/en/homepage-examples/juju-example

Check, in each case, that you end up on a readable documentation page.