### PR TITLE
Redirect landscape-api to api

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -13,6 +13,9 @@ conjure-up/(?P<page>.*): https://docs.conjure-up.io/{page}
 snap-enterprise-proxy: /snap-store-proxy/en/
 snap-enterprise-proxy/(?P<page>.*): /snap-store-proxy/{page}
 
+# Landsacpe
+landscape/en/landscape-api/?: /landscape/en/api
+
 # Documentation-builder
 documentation-builder/?: https://github.com/canonical-webteam/documentation-builder/tree/master/docs
 documentation-builder/(?P<page>.*)/: https://github.com/canonical-webteam/documentation-builder/tree/master/docs/{page}


### PR DESCRIPTION
The document has been renamed, so we need to redirect the old URL.

Fixes https://github.com/canonical-docs/landscape-docs/issues/82

## QA

Go to https://docs-ubuntu-com-canonical-websites-pr-207.run.demo.haus/landscape/en/landscape-api, see that you're redirected to https://docs-ubuntu-com-canonical-websites-pr-207.run.demo.haus/landscape/en/api.

Or to test it locally:

`./run`, then go to http://0.0.0.0:8007/landscape/en/landscape-api and check you are redirected to http://0.0.0.0:8007/landscape/en/api