### PR TITLE
Revert Django update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==2.1.7
+Django==1.11.18
 canonicalwebteam.custom_response_headers==0.2.0
 canonicalwebteam.versioned-static==1.0.2
 canonicalwebteam.yaml-responses==1.1.0


### PR DESCRIPTION
## Done

Fixes https://github.com/canonical-websites/docs.ubuntu.com/issues/208
Revert django update from v2.x to v1.x

It seems that the way we handle 404s don't work anymore on, instead we get 500.
We should update the way we handle errors to make sure it works with v2

## QA

- `./run`
- http://0.0.0.0:8007/landscape/en/onprem-overview
- Should get a 404